### PR TITLE
[stable/fluent-bit] Stackdriver backend

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluent-bit
-version: 2.4.3
+version: 2.5.0
 appVersion: 1.2.1
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -71,6 +71,10 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `backend.splunk.tls_verify`           | Force TLS certificate validation | `off` |
 | `backend.splunk.tls_debug`        | Set TLS debug verbosity level. It accept the following values: 0-4 | `1` |
 | `backend.splunk.message_key`           | Tag applied to all incoming logs | `kubernetes` |
+| **Stackdriver Backend**              |
+| `backend.stackdriver.google_service_credentials`           | Contents of a Google Cloud credentials JSON file. | `` |
+| `backend.stackdriver.service_account_email`           | Account email associated to the service. Only available if no credentials file has been provided. | `` |
+| `backend.stackdriver.service_account_secret`            | Private key content associated with the service account. Only available if no credentials file has been provided. | `` |
 | **Parsers**                   |
 | `parsers.enabled`                  | Enable custom parsers | `false` |
 | `parsers.regex`                    | List of regex parsers | `NULL` |

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -133,6 +133,17 @@ data:
         TLS.Verify   {{ .Values.backend.splunk.tls_verify }}
         tls.debug {{ .Values.backend.splunk.tls_debug }}
         Message_Key   {{ .Values.backend.splunk.message_key }}
+{{ else if eq .Values.backend.type "stackdriver" }}
+    [OUTPUT]
+        Name  stackdriver
+        Match *
+        resource global
+{{- if .Values.backend.stackdriver.google_service_credentials }}
+        google_service_credentials /secure/google_service_credentials.json
+{{- else }}
+        service_account_email  {{ .Values.backend.stackdriver.service_account_email }}
+        service_account_secret  {{ .Values.backend.stackdriver.service_account_secret }}
+{{- end }}
 {{ else if eq .Values.backend.type "http" }}
     [OUTPUT]
         Name  http

--- a/stable/fluent-bit/templates/daemonset.yaml
+++ b/stable/fluent-bit/templates/daemonset.yaml
@@ -97,9 +97,14 @@ spec:
           mountPath: /fluent-bit/etc/parsers_custom.conf
           subPath: parsers.conf
 {{- end }}
+{{- if and .Values.backend.type "stackdriver" .Values.backend.stackdriver.google_service_credentials }}
+        - name: fluentbit-secret
+          mountPath: /secure/google_service_credentials.json
+          subPath: google_service_credentials.json
+{{- end }}
 {{- end }}
 {{- if .Values.backend.es.tls_ca }}
-        - name: es-tls-secret
+        - name: fluentbit-secret
           mountPath: /secure/es-tls-ca.crt
           subPath: es-tls-ca.crt
 {{- end }}
@@ -141,11 +146,9 @@ spec:
           path: /etc/machine-id
           type: File
     {{- end }}
-{{- if .Values.backend.es.tls_ca }}
-      - name: es-tls-secret
+      - name: fluentbit-secret
         secret:
-          secretName: "{{ template "fluent-bit.fullname" . }}-es-tls-secret"
-{{- end }}
+          secretName: "{{ template "fluent-bit.fullname" . }}-secret"
 {{- if .Values.trackOffsets }}
       - name: tail-db
         hostPath:

--- a/stable/fluent-bit/templates/secret.yaml
+++ b/stable/fluent-bit/templates/secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: "{{ template "fluent-bit.fullname" . }}-es-tls-secret"
+  name: "{{ template "fluent-bit.fullname" . }}-secret"
   labels:
     app: {{ template "fluent-bit.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
@@ -10,3 +10,6 @@ metadata:
 type: Opaque
 data:
   es-tls-ca.crt: {{ .Values.backend.es.tls_ca | b64enc | quote }}
+{{- if .Values.backend.stackdriver.google_service_credentials }}
+  google_service_credentials.json: {{ .Values.backend.stackdriver.google_service_credentials | b64enc | quote }}
+{{- end }}

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -80,6 +80,10 @@ backend:
     tls_verify: "off"
     tls_debug: 1
     message_key: "kubernetes"
+  stackdriver:
+    google_service_credentials:
+    service_account_email:
+    service_account_secret:
 
   ##
   ## Ref: http://fluentbit.io/documentation/current/output/http.html


### PR DESCRIPTION
This PR implements the Stackdriver backend to allow Fluent-bit to log outputs to the Google Cloud Stackdriver. Chart implementation follow the official documentation in https://docs.fluentbit.io/manual/v/1.2/output/stackdriver

This is interim for including the chart into our helm-repository, while waiting for PR to official repo here https://github.com/helm/charts/pull/15549